### PR TITLE
Replace @project.verion@ with ${project.version}

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SSX-Connector
 main: xyz.derkades.ssx_connector.Main
-version: '@project.version@'
+version: ${project.version}
 author: Derkades
 description: 'Addon plugin for ServerSelectorX'
 


### PR DESCRIPTION
When using the `<resources></resources>` tags with the `<filtering>true</filtering>` tags should it be possible (emphasis on should) to use `${project.version}` and not rely on any (external) thing like the `@project.version@` you seem to use.

See https://maven.apache.org/pom.html#Resources for reference.